### PR TITLE
SQL statement unquoting and reference to non-existent class 'Concept'

### DIFF
--- a/application/models/Quiz/Concept.php
+++ b/application/models/Quiz/Concept.php
@@ -83,7 +83,7 @@ class Model_Quiz_Concept
 		$stmt = $db->query($sql);
 		$row = $stmt->fetch();
 		if($row['concept_name']!=null){
-			return Concept::fromID($row['concept_name']);
+			return Model_Quiz_Concept::fromID($row['concept_name']);
 		}else{
 			return null; //Something didn't happen
 		}

--- a/application/models/Quiz/QuestionBase.php
+++ b/application/models/Quiz/QuestionBase.php
@@ -102,7 +102,7 @@ class Model_Quiz_QuestionBase
 		//Now find the appropriate entry in the database
 		//	A safe (default) assumption for this is a query that looks for everything you just put in.
 		
-		$sql = "SELECT question_id FROM question_base WHERE xml='".$db->quote($xml)."'";
+		$sql = "SELECT question_id FROM question_base WHERE xml=".$db->quote($xml)."";
 		
 		$result = $db->query($sql);
 		$row = $result->fetch();


### PR DESCRIPTION
Made a couple of minor changes that seemed to be needed during a test deployment.

Namely: (1) removed some quotes in a SQL statement in function Model_Quiz_QuestionBase.fromScratch() and (2) changed a reference to a non-existing class.

modified:   application/models/Quiz/Concept.php
modified:   application/models/Quiz/QuestionBase.php
