### PR TITLE
GD/Image Rendering of HTML Entities

### DIFF
--- a/application/models/Image/Generator.php
+++ b/application/models/Image/Generator.php
@@ -42,6 +42,7 @@
 				
 				//Interpret TABs correctly (this is WAAAAAY Beta)
 				$row = str_replace("\t","      ",$row);
+				$row = html_entity_decode($row);
 				imagettftext($im, 12, 0, 5, ($rowNum*23)+50, $textcolor, APPLICATION_PATH . "/../resources/couri.ttf", $row);
 
 				//imagestring($im, 5, 0, $rowNum*30, $row, $textcolor);


### PR DESCRIPTION
Made HTML entities (e.g. `&lt;`) render correctly in image generated by GD (thanks to the html_entity_decode() function). See also: the 'text' parameter of imagettftext() http://php.net/manual/en/function.imagettftext.php.

modified:   Generator.php
